### PR TITLE
Retrict types on dispatching and listener functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+Use the following sections:
+- `Added`
+- `Changed`
+- `Deprecated`
+- `Removed`
+- `Fixed`
+- `Security`
+
+## 0.1.5
+### Added
+- `dispatchLocalEvent`, `addLocalListener`, `removeLocalListener`
+     These local versions explicitly affect events in over the current Action's scope.
+
+### Changed
+- `dispatchEvent`, `addListener`, `removeListener`
+    These now operate ONLY on the global level, and thus only accept `App` types.
+    Migration: change existing `dispatchEvent` on `Actions` to `dispatchLocalEvent`
+    (and similar for addListener and removeListener) 

--- a/eve.cabal
+++ b/eve.cabal
@@ -1,5 +1,5 @@
 name:                eve
-version:             0.1.4
+version:             0.1.5
 synopsis: An extensible event framework
 description: An extensible event-driven application framework in haskell for building embarassingly modular software.
 homepage:            https://github.com/ChrisPenner/eve#readme

--- a/src/Eve.hs
+++ b/src/Eve.hs
@@ -16,13 +16,23 @@ module Eve
   -- * Dispatching Events
   , dispatchEvent
   , dispatchEvent_
+
+  , dispatchLocalEvent
+  , dispatchLocalEvent_
+
   , dispatchEventAsync
   , dispatchActionAsync
 
   -- * Event Listeners
   , addListener
   , addListener_
+
+  , addLocalListener
+  , addLocalListener_
+
   , removeListener
+  , removeLocalListener
+
   , Listener
   , ListenerId
 

--- a/test/Eve/Internal/ListenersSpec.hs
+++ b/test/Eve/Internal/ListenersSpec.hs
@@ -34,6 +34,11 @@ asyncEventsTest = do
   asyncEventProvider (\d -> d CustomEvent)
   store .= "new"
 
+localEventsTest :: Action NestedStates ()
+localEventsTest = do
+  addLocalListener (const (nestedString .= "new") :: CustomEvent -> Action NestedStates ())
+  dispatchEvent CustomEvent
+
 data OtherEvent = OtherEvent
 multiAsyncEventsTest :: App ()
 multiAsyncEventsTest = do
@@ -45,13 +50,19 @@ spec :: Spec
 spec = do
   describe "dispatchEvent/addListener" $
     it "Triggers Listeners" $ fst (noIOTest basicAction) `shouldBe` "new"
+
   describe "dispatchEventAsync" $ do
     delayedExitState <- ioTest delayedExit
     it "Triggers Listeners Eventually" $ (delayedExitState ^. store) `shouldBe` "new"
+
   describe "removeListener" $
     it "Removes Listeners" $ fst (noIOTest removeListenersTest) `shouldBe` "default"
+
   describe "asyncEventProvider" $ do
     asyncEventsResult <- ioTest asyncEventsTest
     it "Provides events eventually" $ (asyncEventsResult ^. store) `shouldBe` "new"
     multiAsyncEventsResult <- ioTest multiAsyncEventsTest
     it "Can provide different event types" $ (multiAsyncEventsResult ^. store) `shouldBe` "new"
+
+--   describe "removeListener" $
+--     it "Removes Listeners" $ fst (noIOTest removeListenersTest) `shouldBe` "default"

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -4,6 +4,8 @@ module Fixtures
   , CustomEvent(..)
   , noIOTest
   , ioTest
+  , NestedStates
+  , nestedString
   ) where
 
 import Eve.Testing
@@ -18,6 +20,20 @@ import Data.Default
 
 import Test.Hspec.Core.Spec (SpecM)
 import Test.Hspec
+
+data NestedStates = NestedStates
+  { _nestedStates :: States
+  , _nestedString :: String
+  }
+makeLenses ''NestedStates
+
+instance Default NestedStates where
+  def = NestedStates mempty "default"
+
+instance HasStates NestedStates where
+  states = nestedStates
+
+instance HasEvents NestedStates
 
 data Store = Store
   {_payload :: String

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -6,6 +6,7 @@ module Fixtures
   , ioTest
   , NestedStates
   , nestedString
+  , nestedStates
   ) where
 
 import Eve.Testing
@@ -22,7 +23,7 @@ import Test.Hspec.Core.Spec (SpecM)
 import Test.Hspec
 
 data NestedStates = NestedStates
-  { _nestedStates :: States
+  { _nestedStates' :: States
   , _nestedString :: String
   }
 makeLenses ''NestedStates
@@ -31,9 +32,12 @@ instance Default NestedStates where
   def = NestedStates mempty "default"
 
 instance HasStates NestedStates where
-  states = nestedStates
+  states = nestedStates'
 
 instance HasEvents NestedStates
+
+nestedStates :: HasStates s => Lens' s NestedStates
+nestedStates = stateLens
 
 data Store = Store
   {_payload :: String


### PR DESCRIPTION
Adds 'local' versions of dispatchEvent, addListener, removeListener which affect local event state;
the non-local versions now always lift their effects to the App level.