### PR TITLE
Simplify runAction for the basic use-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Use the following sections:
 - `Removed`
 - `Fixed`
 - `Security`
+- `Migration`
+
+## 0.1.6
+### Added
+-   `runActionOver`: This is equivalent to `runAction` in 0.1.5
+
+
+### Changed
+- `runAction` now assumes the `stateLens` by default, if you wish to specify a 
+
+### Migration
+- Change occurances of `runAction` to `runActionOver` and occurances of `runAction stateLens`
+    to just `runAction`.
 
 ## 0.1.5
 ### Added
@@ -15,5 +28,7 @@ Use the following sections:
 ### Changed
 - `dispatchEvent`, `addListener`, `removeListener`
     These now operate ONLY on the global level, and thus only accept `App` types.
-    Migration: change existing `dispatchEvent` on `Actions` to `dispatchLocalEvent`
-    (and similar for addListener and removeListener) 
+
+### Migration
+-   Change existing `dispatchEvent` on `Actions` to `dispatchLocalEvent` (and
+    similar for addListener and removeListener)

--- a/eve.cabal
+++ b/eve.cabal
@@ -1,5 +1,5 @@
 name:                eve
-version:             0.1.5
+version:             0.1.6
 synopsis: An extensible event framework
 description: An extensible event-driven application framework in haskell for building embarassingly modular software.
 homepage:            https://github.com/ChrisPenner/eve#readme

--- a/src/Eve.hs
+++ b/src/Eve.hs
@@ -11,6 +11,7 @@ module Eve
   , ActionT
   , liftApp
   , runAction
+  , runActionOver
   , exit
 
   -- * Dispatching Events

--- a/src/Eve/Internal/Actions.hs
+++ b/src/Eve/Internal/Actions.hs
@@ -61,16 +61,17 @@ type instance Zoomed (ActionT base zoomed m) = Zoomed (FreeT (AppF base m) (Stat
 instance Monad m => Zoom (ActionT base s m) (ActionT base t m) s t where
   zoom l (ActionT action) = ActionT $ zoom l action
 
--- | This runs an `Aciton MyState a` over a MyState which is stored in the
--- currently focused state and returns the result.
+-- | This runs an `Action MyState a` over the MyState which is
+-- stored in the currently focused state and returns the result.
+-- Use 'runActionOver' if you'd like to specify a particular MyState
+-- which is accessed by a Lens or Traversal.
 runAction :: (HasStates t, Functor (Zoomed m c), Default s, Typeable s, Zoom m n s t) => m c -> n c
 runAction = zoom stateLens
 
--- | Given a 'Lens' or 'Traversal' or something similar from "Control.Lens"
+-- | Given a 'Lens' or 'Traversal' or LensLike from "Control.Lens"
 -- which focuses the state (t) of an 'Action' from a base state (s),
--- this will convert @Action t a -> Action s a@.
---
--- Given a lens @HasStates s => Lens' s t@ it can also convert @Action t a -> App a@
+-- this will convert @Action t a -> Action s a@ so that it may be run
+-- in an @Action s a@
 runActionOver :: Zoom m n s t => LensLike' (Zoomed m c) t s -> m c -> n c
 runActionOver = zoom
 

--- a/src/Eve/Internal/Actions.hs
+++ b/src/Eve/Internal/Actions.hs
@@ -1,6 +1,7 @@
 {-# language GeneralizedNewtypeDeriving #-}
 {-# language DeriveFunctor #-}
 {-# language FlexibleInstances #-}
+{-# language FlexibleContexts #-}
 {-# language MultiParamTypeClasses #-}
 {-# language RankNTypes #-}
 {-# language TypeFamilies #-}
@@ -17,11 +18,15 @@ module Eve.Internal.Actions
 
   , liftApp
   , runAction
+  , runActionOver
   ) where
 
+import Eve.Internal.States
 import Control.Monad.State
 import Control.Monad.Trans.Free
 import Control.Lens
+import Data.Typeable
+import Data.Default
 
 -- | An 'App' has the same base and zoomed values.
 type AppT s m a = ActionT s s m a
@@ -56,13 +61,18 @@ type instance Zoomed (ActionT base zoomed m) = Zoomed (FreeT (AppF base m) (Stat
 instance Monad m => Zoom (ActionT base s m) (ActionT base t m) s t where
   zoom l (ActionT action) = ActionT $ zoom l action
 
+-- | This runs an `Aciton MyState a` over a MyState which is stored in the
+-- currently focused state and returns the result.
+runAction :: (HasStates t, Functor (Zoomed m c), Default s, Typeable s, Zoom m n s t) => m c -> n c
+runAction = zoom stateLens
+
 -- | Given a 'Lens' or 'Traversal' or something similar from "Control.Lens"
 -- which focuses the state (t) of an 'Action' from a base state (s),
 -- this will convert @Action t a -> Action s a@.
 --
 -- Given a lens @HasStates s => Lens' s t@ it can also convert @Action t a -> App a@
-runAction :: Zoom m n s t => LensLike' (Zoomed m c) t s -> m c -> n c
-runAction = zoom
+runActionOver :: Zoom m n s t => LensLike' (Zoomed m c) t s -> m c -> n c
+runActionOver = zoom
 
 -- | Allows you to run an 'App' or 'AppM' inside of an 'Action' or 'ActionM'
 liftApp :: Monad m => AppT base m a -> ActionT base zoomed m a

--- a/test/Eve/Internal/ListenersSpec.hs
+++ b/test/Eve/Internal/ListenersSpec.hs
@@ -43,7 +43,7 @@ localStateIsolationTest = do
 globalStateIsolationTest :: AppT AppState Identity String
 globalStateIsolationTest = do
   addListener (const (store .= "new") :: CustomEvent -> AppT AppState Identity ())
-  runAction nestedStates $ do
+  runActionOver nestedStates $ do
     dispatchLocalEvent_ CustomEvent
   use store
 
@@ -53,7 +53,7 @@ listenerPassThroughTest = do
       nestedAction = do
         addListener (const (store .= "new") :: CustomEvent -> AppT AppState Identity ())
         dispatchEvent CustomEvent
-  runAction nestedStates nestedAction
+  runActionOver nestedStates nestedAction
   use store
 
 
@@ -70,7 +70,7 @@ spec = do
     it "Triggers Listeners" $ fst (noIOTest basicAction) `shouldBe` "new"
 
   describe "local events" $ do
-    it "local state is isolated from global events" $ fst (noIOTest $ runAction stateLens localStateIsolationTest) `shouldBe` "default"
+    it "local state is isolated from global events" $ fst (noIOTest $ runAction localStateIsolationTest) `shouldBe` "default"
     it "global state is isolated from local events" $ fst (noIOTest globalStateIsolationTest) `shouldBe` "default"
     it "global event actions pass through from local state" $ fst (noIOTest listenerPassThroughTest) `shouldBe` "new"
 


### PR DESCRIPTION
### Added
-   `runActionOver`: This is equivalent to `runAction` in 0.1.5

### Changed
- `runAction` now assumes the `stateLens` by default, if you wish to specify a 

### Migration
- Change occurances of `runAction` to `runActionOver` and occurances of `runAction stateLens`
    to just `runAction`.
