### PR TITLE
Add semigroup instance for ActionT

### DIFF
--- a/eve.cabal
+++ b/eve.cabal
@@ -30,6 +30,7 @@ library
                      , free
                      , data-default
                      , containers
+                     , semigroups
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/src/Eve/Internal/Actions.hs
+++ b/src/Eve/Internal/Actions.hs
@@ -27,6 +27,7 @@ import Control.Monad.Trans.Free
 import Control.Lens
 import Data.Typeable
 import Data.Default
+import Data.Semigroup
 
 -- | An 'App' has the same base and zoomed values.
 type AppT s m a = ActionT s s m a
@@ -42,12 +43,15 @@ newtype ActionT base zoomed m a = ActionT
   { getAction :: FreeT (AppF base m) (StateT zoomed m) a
   } deriving (Functor, Applicative, Monad, MonadIO, MonadState zoomed)
 
-instance (Monoid a, Monad m) => Monoid (ActionT base zoomed m a) where
-  mempty = return mempty
-  a `mappend` b = do
+instance (Semigroup a, Monad m) => Semigroup (ActionT base zoomed m a) where
+  a <> b = do
     a' <- a
     b' <- b
-    return $ a' `mappend` b'
+    return $ a' <> b'
+
+instance (Monoid a, Monad m) => Monoid (ActionT base zoomed m a) where
+  mempty = return mempty
+  mappend = (<>)
 
 instance Monad n => MonadFree (AppF base n) (ActionT base zoomed n) where
   wrap (RunApp act) = join . ActionT . liftF . RunApp $ act


### PR DESCRIPTION
Had a bit of fun setting up a rasa editor, ran into a small issue :).

I had to do this in order to compile with newer (8.4.1 >= ... I think) ghc versions. Adding the Semigroups import is intended to make this backwards compatible (following the advice from [here](https://blog.qfpl.io/posts/semigroups/)); though I haven't actually checked with older GHCs :grimacing: yet. 

It [appears to work](https://github.com/bradparker/editor-two/blob/master/default.nix#L5-L10) (albeit with a warning that the `Data.Semigroup` import is unneeded) with ghc 8.4.3 in any case.

Maybe this is useful. Thanks.