### PR TITLE
Fix GHC 9.8 compatibility by adding missing Control.Monad imports

### DIFF
--- a/src/Eve/Internal/Actions.hs
+++ b/src/Eve/Internal/Actions.hs
@@ -22,6 +22,7 @@ module Eve.Internal.Actions
   ) where
 
 import Eve.Internal.States
+import Control.Monad (join)
 import Control.Monad.State
 import Control.Monad.Trans.Free
 import Control.Lens

--- a/src/Eve/Internal/Listeners.hs
+++ b/src/Eve/Internal/Listeners.hs
@@ -38,6 +38,7 @@ import Eve.Internal.Async
 import Eve.Internal.Actions
 import Eve.Internal.Events
 
+import Control.Monad (void)
 import Control.Monad.State
 import Control.Lens
 


### PR DESCRIPTION
The package was not building and I want to play around with it. The tests seem to run but please let me know if there's anything else I need to do to get this merged!